### PR TITLE
UseCasePattern::ValidationError is raised by perform!

### DIFF
--- a/lib/use_case_pattern/base.rb
+++ b/lib/use_case_pattern/base.rb
@@ -28,7 +28,10 @@ module UseCasePattern
     end
 
     def perform!
-      valid? || raise(ValidationError.new)
+      if invalid?
+        raise(ValidationError.new(self))
+      end
+
       perform
     end
 
@@ -54,5 +57,12 @@ module UseCasePattern
   # This class may be deprecated by ActiveModel::ValidationError in the future.
   #
   class ValidationError < StandardError
+    attr_reader :model
+
+    def initialize(model)
+      @model = model
+      errors = @model.errors.full_messages.join(", ")
+      super("Validation failed: " + errors)
+    end
   end
 end

--- a/lib/use_case_pattern/base.rb
+++ b/lib/use_case_pattern/base.rb
@@ -28,13 +28,8 @@ module UseCasePattern
     end
 
     def perform!
-      if valid?
-        perform
-      end
-
-      if failure?
-        raise_validation_error
-      end
+      valid? || raise(ValidationError.new)
+      perform
     end
 
     # Did the use case performed its task without errors?
@@ -46,5 +41,18 @@ module UseCasePattern
     def failure?
       errors.any?
     end
+  end
+
+  # Use Case Pattern ValidationError
+  #
+  # Raised by <tt>perform!</tt> when validations result in errors.
+  #
+  # Check the use case +errors+ object for attribute error messages.
+  #
+  # ActiveModel 5.0 has an ActiveModel::ValidationError class, prior versions including 4.2 do not.
+  #
+  # This class may be deprecated by ActiveModel::ValidationError in the future.
+  #
+  class ValidationError < StandardError
   end
 end

--- a/spec/use_case_pattern/base_spec.rb
+++ b/spec/use_case_pattern/base_spec.rb
@@ -53,7 +53,7 @@ describe UseCasePattern::Base do
 
     describe "#perform!" do
       it "should raise an error" do
-        expect { UseCaseThatGeneratesErrors.perform!(nil) }.to raise_error(UseCasePattern::ValidationError)
+        expect { UseCaseThatGeneratesErrors.perform!(nil) }.to raise_error(UseCasePattern::ValidationError, "Validation failed: Age can't be blank")
       end
     end
   end

--- a/spec/use_case_pattern/base_spec.rb
+++ b/spec/use_case_pattern/base_spec.rb
@@ -53,7 +53,7 @@ describe UseCasePattern::Base do
 
     describe "#perform!" do
       it "should raise an error" do
-        expect { UseCaseThatGeneratesErrors.perform!(nil) }.to raise_error(ActiveModel::ValidationError, "Validation failed: Age can't be blank")
+        expect { UseCaseThatGeneratesErrors.perform!(nil) }.to raise_error(UseCasePattern::ValidationError)
       end
     end
   end


### PR DESCRIPTION
This makes UseCasePattern validations work with versions of ActiveModel less than 5.0.

ActiveModel::ValidationError is introduced by this commit:

https://github.com/rails/rails/commit/830b7041f213669c3877edf459ef83a31c84cc4d